### PR TITLE
Use UnsafeCell for char_buf to make modern Rust linter happy

### DIFF
--- a/src/evaler.rs
+++ b/src/evaler.rs
@@ -418,13 +418,13 @@ impl Evaler for StdFunc {
             #[cfg(feature="unsafe-vars")]
             EUnsafeVar{ptr, ..} => unsafe { Ok(**ptr) },
 
-            EVar(name) => eval_var!(ns, name, Vec::new(), unsafe{ &mut *(&slab.ps.char_buf as *const _ as *mut _) }),
+            EVar(name) => eval_var!(ns, name, Vec::new(), unsafe{ &mut *slab.ps.char_buf.get() }),
             EFunc{name, args:xis} => {
                 let mut args = Vec::with_capacity(xis.len());
                 for xi in xis {
                     args.push(get_expr!(slab.ps,xi).eval(slab,ns)?)
                 }
-                eval_var!(ns, name, args, unsafe{ &mut *(&slab.ps.char_buf as *const _ as *mut _) })
+                eval_var!(ns, name, args, unsafe { &mut *slab.ps.char_buf.get() })
             }
 
             EFuncLog{base:base_opt, expr:expr_i} => {
@@ -584,13 +584,13 @@ impl Evaler for Instruction {
             INeg(i) => Ok(-eval_compiled_ref!(get_instr!(slab.cs,i), slab, ns)),
             IInv(i) => Ok(1.0/eval_compiled_ref!(get_instr!(slab.cs,i), slab, ns)),
 
-            IVar(name) => eval_var!(ns, name, Vec::new(), unsafe{ &mut *(&slab.ps.char_buf as *const _ as *mut _) }),
+            IVar(name) => eval_var!(ns, name, Vec::new(), unsafe { &mut *slab.ps.char_buf.get() }),
             IFunc{name, args:ics} => {
                 let mut args = Vec::with_capacity(ics.len());
                 for ic in ics {
                     args.push( eval_ic_ref!(ic, slab, ns) );
                 }
-                eval_var!(ns, name, args, unsafe{ &mut *(&slab.ps.char_buf as *const _ as *mut _) })
+                eval_var!(ns, name, args, unsafe { &mut *slab.ps.char_buf.get() })
             },
 
             IFuncLog{base:baseic, of:ofic} => {
@@ -701,4 +701,3 @@ impl Evaler for Instruction {
         }
     }
 }
-

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -396,11 +396,14 @@ impl Parser {
                         _ => (0,0),
                     };
                     if exp!=0 {
-                        slab.char_buf.clear();
-                        slab.char_buf.push_str(tok);
-                        slab.char_buf.push('e');
-                        slab.char_buf.push_str(&exp.to_string());
-                        tok = &slab.char_buf;
+                        unsafe {
+                            let char_buf = &mut *slab.char_buf.get();
+                            char_buf.clear();
+                            char_buf.push_str(tok);
+                            char_buf.push('e');
+                            char_buf.push_str(&exp.to_string());
+                            tok = char_buf;
+                        }
 
                         toklen = toklen+suffixlen;
                     }

--- a/src/slab.rs
+++ b/src/slab.rs
@@ -58,6 +58,7 @@ use crate::compiler::{Instruction::{self, IConst}, InstructionI};
 
 use std::fmt;
 use std::mem;
+use std::cell::UnsafeCell;
 
 #[cfg(feature="unsafe-vars")]
 use std::collections::BTreeMap;
@@ -215,7 +216,7 @@ pub struct ParseSlab {
     pub(crate) vals       :Vec<Value>,
     pub(crate) def_expr   :Expression,
     pub(crate) def_val    :Value,
-    pub(crate) char_buf   :String,
+    pub(crate) char_buf   :UnsafeCell<String>,
     #[cfg(feature="unsafe-vars")]
     pub(crate) unsafe_vars:BTreeMap<String, *const f64>,
 }
@@ -355,7 +356,7 @@ impl Slab {
                 vals       :Vec::with_capacity(cap),
                 def_expr   :Default::default(),
                 def_val    :Default::default(),
-                char_buf   :String::with_capacity(64),
+                char_buf   :UnsafeCell::new(String::with_capacity(64)),
                 #[cfg(feature="unsafe-vars")]
                 unsafe_vars:BTreeMap::new(),
             },


### PR DESCRIPTION
Use `slab.ps.char_buf: UnsafeCell<String>`  to avoid `invalid_reference_casting` errors in lines like this:

```
EVar(name) => eval_var!(ns, name, Vec::new(), unsafe{ &mut *(&slab.ps.char_buf as *const _ as *mut _) }),
                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

It is a zero-cost abstraction, so there is no additional overhead or performance hit.